### PR TITLE
Update docstring formatting in `getPotentialParentFromSettingValue`

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -226,6 +226,10 @@ class Case:
         """
         Get a parent case based on a setting value and a pattern.
 
+        This is a convenient way for a plugin to express a dependency. It uses the
+        ``match.groupdict`` functionality to pull the directory and case name out of a
+        specific setting value an regular expression.
+        
         Parameters
         ----------
         settingValue : str
@@ -236,10 +240,6 @@ class Case:
             If the ``settingValue`` matches the passed pattern, this function will
             attempt to extract the ``dirName`` and ``title`` groups to find the
             dependency.
-
-        This is a convenient way for a plugin to express a dependency. It uses the
-        ``match.groupdict`` functionality to pull the directory and case name out of a
-        specific setting value an regular expression.
         """
         m = re.match(filePattern, settingValue, re.IGNORECASE)
         deps = self._getPotentialDependencies(**m.groupdict()) if m else set()


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

The docstring was being rendered all crazy:
![image](https://user-images.githubusercontent.com/21959600/164111235-523ef82e-1f1a-42a8-b51a-e61046f60342.png)

Turns out that the ordering of different sections in the docstrings matters, so moved the remainder of the description out of the "Parameters" block.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
